### PR TITLE
Robust shellscript

### DIFF
--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -1,29 +1,32 @@
 #!/bin/bash
 
+set -eu
+set -o pipefail
+
 DEB=$1
 
 ALIEN_OUT=$(mktemp)
-alien --to-rpm --scripts --generate "$DEB" >$ALIEN_OUT
+alien --to-rpm --scripts --generate "$DEB" >"$ALIEN_OUT"
 
-SPEC_DIR=$(awk '/Directory/ {print $2}' $ALIEN_OUT)
+SPEC_DIR=$(awk '/Directory/ {print $2}' "$ALIEN_OUT")
 
 
-pushd $SPEC_DIR
+pushd "$SPEC_DIR" > /dev/null
 
 FS_DIRS=$(mktemp)
-SPEC=$(ls *.spec)
+SPEC=$(ls ./*.spec)
 
-rpm -ql filesystem | sed 's/^/%dir "/; s/$/\/"/; s,//,/,;' >$FS_DIRS
+rpm -ql filesystem | sed 's/^/%dir "/; s/$/\/"/; s,//,/,;' >"$FS_DIRS"
 
 # remove standard dirs from package
-grep -vxf $FS_DIRS $SPEC >$SPEC.nodirs
+grep -vxf "$FS_DIRS" "$SPEC" >"$SPEC.nodirs"
 
 sed '/^Group:/ a \
 # remove requires/provides from bundled libs \
 %global __requires_exclude ^(libQt5|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$ \
 %global __provides_exclude ^(libQt5|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$' \
-        $SPEC.nodirs >$SPEC
+        "$SPEC.nodirs" >"$SPEC"
 
-rpmbuild -bb --define "buildroot $PWD" $SPEC
+rpmbuild -bb --define "buildroot $PWD" "$SPEC"
 
-rm -f $FS_DIRS $ALIEN_OUT
+rm -f "$FS_DIRS" "$ALIEN_OUT"

--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -35,6 +35,8 @@ sed '/^Group:/ a \
 %global __provides_exclude ^(libQt5|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$' \
         "$SPEC.nodirs" >"$SPEC"
 
+rm "$SPEC.nodirs"
+
 rpmbuild -bb --define "buildroot $PWD" "$SPEC"
 
 _cleanup


### PR DESCRIPTION
Quote all variables to avoid word splitting as reported with https://www.shellcheck.net/

Use `./*.spec` to ensure dash-prefixed filenames are not treated as command options. Also from Shellcheck.

Set couple of shell options for more robust runs:

- "-e" from man page: Exit immediately if a pipeline (which may consist of a single simple command), a list, or a compound command (see SHELL GRAMMAR above), exits with  a non-zero  status.
- "-u from man page: Treat unset variables and parameters other than the special parameters "@" and "*" as an error when performing parameter expansion.
- "-o pipefail" from man page: If  set,  the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully.

Cleanup temporary directories automatically with `trap` catching couple of common signals.

Cleanup of tempory spec file.

Do not print directory name on `pushd` (not really robustness but less confusing verbosity).