### PR TITLE
Adopt new Qt6 and openssl3.0 deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ EN: An unofficial guide on how to use eObcanka on Fedora by converting the offic
 
 # Jak na to / How to
 
-CZ: Postup je otestovaný s Fedorou 39 a s verzí DEB balíčku 3.4.0.
+CZ: Postup je otestovaný s Fedorou 40 a s verzí DEB balíčku 3.4.2.
 
-EN: Tested on Fedora 39 with the version of the DEB package 3.4.0.  The app itself is not translated, so a quick translation:
+EN: Tested on Fedora 40 with the version of the DEB package 3.4.2.  The app itself is not translated, so a quick translation:
 1. First it's going to tell you _"Vložte občanský průkaz!"_ meaning that you should insert the eObcanka to your card reader.
 2. Tick the checkbox _"Automaticky pokračovat po vložení občanského průkazu"_ meaning that the authentication process will continue automatically upon detecting an inserted eObcanka card.
 3. You should then see _"Zadejte identifikační osobní kód"_ meaning that you should enter your IOK - a number you set up when picking up your card.

--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -31,20 +31,6 @@ pushd "$SPEC_DIR" > /dev/null
 
 SPEC=$(ls ./*.spec)
 
-fedora_version=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release)
-if [ "fedora_version" -le 39 ]; then
-  # Replace the libcrypto library that comes with the deb package with a symlink to the system one to avoid error:
-  #     symbol lookup error: /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
-  # See: https://forum.mojefedora.cz/t/eobcanka/7941/8 or https://bugzilla.redhat.com/show_bug.cgi?id=1829790#c9
-  # Fedora 40 does not ship openssl1.1 anymore but newer versions of the eObcanka package (such as 3.4.2) work with
-  #  openssl3.0 anyway.
-  rm "opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1"
-  sed -i '/^%postun/ i ln -fs /usr/lib64/libcrypto.so.1.1 /opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1' "$SPEC"
-  sed -i 's/^\(".*\/libcrypto.so.1.1"\)$/%ghost \1/' "$SPEC"
-  # Make sure the openssl1.1 package is installed on the system
-  sed -i '/^Group:/ a Requires: openssl1.1' "$SPEC"
-fi
-
 # Require Czech locale package and remove Debian-specific local-gen.
 # The piece of code we want to remove from the spec file is:
 # ```

--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -31,17 +31,31 @@ pushd "$SPEC_DIR" > /dev/null
 
 SPEC=$(ls ./*.spec)
 
-# Replace upstream libcrypto library with a symlink to system one to avoid error:
-#     symbol lookup error: /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
-# See: https://forum.mojefedora.cz/t/eobcanka/7941/8 or https://bugzilla.redhat.com/show_bug.cgi?id=1829790#c9
-rm "opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1"
-sed -i '/^%postun/ i ln -fs /usr/lib64/libcrypto.so.1.1 /opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1' "$SPEC"
-sed -i 's/^\(".*\/libcrypto.so.1.1"\)$/%ghost \1/' "$SPEC"
+fedora_version=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release)
+if [ "fedora_version" -le 39 ]; then
+  # Replace the libcrypto library that comes with the deb package with a symlink to the system one to avoid error:
+  #     symbol lookup error: /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
+  # See: https://forum.mojefedora.cz/t/eobcanka/7941/8 or https://bugzilla.redhat.com/show_bug.cgi?id=1829790#c9
+  # Fedora 40 does not ship openssl1.1 anymore but newer versions of the eObcanka package (such as 3.4.2) work with
+  #  openssl3.0 anyway.
+  rm "opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1"
+  sed -i '/^%postun/ i ln -fs /usr/lib64/libcrypto.so.1.1 /opt/eObcanka/lib/openssl1.1/libcrypto.so.1.1' "$SPEC"
+  sed -i 's/^\(".*\/libcrypto.so.1.1"\)$/%ghost \1/' "$SPEC"
+  # Make sure the openssl1.1 package is installed on the system
+  sed -i '/^Group:/ a Requires: openssl1.1' "$SPEC"
+fi
 
-# Require Czech locale package and remove Debian-specific local-gen
-sed -i '/^Group:/ a\
-Requires: glibc-langpack-cs\
-Requires: openssl1.1' "$SPEC"
+# Require Czech locale package and remove Debian-specific local-gen.
+# The piece of code we want to remove from the spec file is:
+# ```
+# ##CZ language support
+# ISLANGCSACTIVE=$(/usr/bin/locale -a|grep cs_CZ)
+#
+# if [ -z $ISLANGCSACTIVE ] ; then
+#    locale-gen cs_CZ.utf8
+# fi
+# ```
+sed -i '/^Group:/ a Requires: glibc-langpack-cs' "$SPEC"
 sed -i '/##CZ/{:a;N;/utf8\nfi/!ba};//d' "$SPEC"
 
 rpm -ql filesystem | sed 's/^/%dir "/; s/$/\/"/; s,//,/,;' >"$FS_DIRS"
@@ -51,8 +65,8 @@ grep -vxf "$FS_DIRS" "$SPEC" >"$SPEC.nodirs"
 
 sed '1i \
 # remove requires/provides from bundled libs \
-%global __requires_exclude ^(libQt5|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$ \
-%global __provides_exclude ^(libQt5|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$\n' \
+%global __requires_exclude ^(libQt6|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$ \
+%global __provides_exclude ^(libQt6|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$\n' \
         "$SPEC.nodirs" >"$SPEC"
 
 rm "$SPEC.nodirs"


### PR DESCRIPTION
The eObcanka deb package 3.4.2 is now using a newer version of Qt (5 -> 6) and a newer version of openssl (1.1 -> 3.0).