### PR TITLE
Don't exclude many Requires/Provides unnecessarily

### DIFF
--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -51,8 +51,7 @@ grep -vxf "$FS_DIRS" "$SPEC" >"$SPEC.nodirs"
 
 sed '1i \
 # remove requires/provides from bundled libs \
-%global __requires_exclude ^(libQt6|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$ \
-%global __provides_exclude ^(libQt6|libicu|libcmprovp11|libcryptoui|libcrypto|libssl|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$\n' \
+%global __requires_exclude ^(libQt6|libeop2v1czep11|libeopczep11|libeopproxyp11|libsa2v1czep11).*$\n' \
         "$SPEC.nodirs" >"$SPEC"
 
 rm "$SPEC.nodirs"


### PR DESCRIPTION
Exclusion of some of the eObcanka rpm required dependencies is not necessary. And excluding what deps the rpm provides is not necessary at all. The app works just fine.