### PR TITLE
Fix setting buildroot for rpmbuild

### DIFF
--- a/eobcanka_deb2rpm.sh
+++ b/eobcanka_deb2rpm.sh
@@ -56,6 +56,6 @@ sed '1i \
 
 rm "$SPEC.nodirs"
 
-rpmbuild -bb --define "buildroot $PWD" "$SPEC"
+rpmbuild -bb --buildroot "$PWD" "$SPEC"
 
 _cleanup


### PR DESCRIPTION
Fedora 41 comes with rpm 4.20 that does not respect the way we were setting the buildroot path.

Resolves #12.